### PR TITLE
ZBUG-2295: Nginx - segfault in HTTP2 (webmail)

### DIFF
--- a/src/core/ngx_palloc.c
+++ b/src/core/ngx_palloc.c
@@ -70,8 +70,6 @@ ngx_destroy_pool(ngx_pool_t *pool)
     }
 
     for (p = pool, n = pool->d.next; /* void */; p = n, n = n->d.next) {
-        ngx_log_debug2(NGX_LOG_DEBUG_ALLOC, pool->log, 0,
-                       "free: %p, unused: %uz", p, p->d.end - p->d.last);
 
         if (n == NULL) {
             break;


### PR DESCRIPTION
**Problem**
- Nginx - segfault in HTTP2 from 1.19.0 release.
- Frequent dumps if HTTP2 is enabled (forcing us to disable HTTP2).
- Dumps persisted even if HTTP2 was disabled but with less occurrence.

```
2021/06/08 21:10:23 [info] 16462#0: *11710308 epoll_wait() reported that client prematurely closed connection, so upstream connection is closed too while connecting to upstream, client: 2a02:a03f:e779:fe00:d114:dcdf:7e33:1621, server: claude.telenet-ops.be, request: "GET /img/zimbra/1x1-trans.png HTTP/1.1", upstream: "http://[2a02:1800:120:86:0:0:f00:6b]:8080/img/zimbra/1x1-trans.png", host: "mail.telenet.be", referrer: "https://mail.telenet.be/zimbra/mail?client=advanced"

2021/06/08 21:10:23 [notice] 16461#0: signal 17 (SIGCHLD) received from 16462

2021/06/08 21:10:23 [alert] 16461#0: worker process 16462 exited on signal 11 (core dumped)

```
**Approach and Fix**
- Remove the usage of logs during free

**Testing done**
- Sanity done locally.
- Tested in Production like environment, no dumps seen.
