### PR TITLE
ZBUG-2299: Memory leak fix

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -1828,7 +1828,7 @@ ngx_ssl_handshake(ngx_connection_t *c)
 
     c->read->error = 1;
 
-    ERR_clear_error();
+    ngx_ssl_connection_error(c, sslerr, err, "SSL_do_handshake() failed");
 
     return NGX_ERROR;
 }
@@ -2899,8 +2899,6 @@ ngx_ssl_shutdown(ngx_connection_t *c)
     ngx_err_t   err;
     ngx_uint_t  tries;
 
-    ngx_ssl_ocsp_cleanup(c);
-
     if (SSL_in_init(c->ssl->connection)) {
         /*
          * OpenSSL 1.0.2f complains if SSL_shutdown() is called during
@@ -2914,6 +2912,8 @@ ngx_ssl_shutdown(ngx_connection_t *c)
 
         return NGX_OK;
     }
+
+   ngx_ssl_ocsp_cleanup(c);
 
     if (c->timedout || c->error || c->buffered) {
         mode = SSL_RECEIVED_SHUTDOWN|SSL_SENT_SHUTDOWN;

--- a/src/mail/ngx_mail_handler.c
+++ b/src/mail/ngx_mail_handler.c
@@ -421,6 +421,8 @@ ngx_mail_ssl_handshake_handler(ngx_connection_t *c)
         ngx_mail_init_session(c);
         return;
     }
+    
+    ngx_mail_close_connection(c);
 }
 
 


### PR DESCRIPTION
**Problem**
- Nginx upgrade to 1.20 caused leaks. 

**Testing done**
- Tested the issue against long running environments, no issues seen.