### PR TITLE
HTTP/2: per-iteration stream handling limit.

### DIFF
--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -361,6 +361,7 @@ ngx_http_v2_read_handler(ngx_event_t *rev)
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "http2 read handler");
 
     h2c->blocked = 1;
+    h2c->new_streams = 0;
 
     if (c->close) {
         c->close = 0;
@@ -1320,6 +1321,14 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
         goto rst_stream;
     }
 
+    if (h2c->new_streams++ >= 2 * h2scf->concurrent_streams) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent too many streams at once");
+
+        status = NGX_HTTP_V2_REFUSED_STREAM;
+        goto rst_stream;
+    }
+
     if (!h2c->settings_ack
         && !(h2c->state.flags & NGX_HTTP_V2_END_STREAM_FLAG)
         && h2scf->preread_size < NGX_HTTP_V2_DEFAULT_WINDOW)
@@ -1384,6 +1393,12 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
     return ngx_http_v2_state_header_block(h2c, pos, end);
 
 rst_stream:
+
+    if (h2c->refused_streams++ > ngx_max(h2scf->concurrent_streams, 100)) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent too many refused streams");
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_NO_ERROR);
+    }
 
     if (ngx_http_v2_send_rst_stream(h2c, h2c->state.sid, status) != NGX_OK) {
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_INTERNAL_ERROR);

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -125,6 +125,8 @@ struct ngx_http_v2_connection_s {
     ngx_uint_t                       processing;
     ngx_uint_t                       frames;
     ngx_uint_t                       idle;
+    ngx_uint_t                       new_streams;
+    ngx_uint_t                       refused_streams;
     ngx_uint_t                       priority_limit;
 
     ngx_uint_t                       pushing;


### PR DESCRIPTION
Please consider this patch for [CVE-2023-44487: HTTP/2 Rapid Reset Attack](https://thehackernews.com/2023/10/http2-rapid-reset-zero-day.html), taken from https://github.com/nginx/nginx/commit/6ceef192e7af1c507826ac38a2d43f08bf265fb9.  It applies cleanly to Zimbra's nginx 1.20 branch.  

We're running this patch in production.